### PR TITLE
Deploy to gh-pages on merge to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   fqdn: dicomsort.com
   committer-from-gh: true
   on:
-    branch: master
+    branch: main


### PR DESCRIPTION
Now that our main branch is `main` rather than `master`, we need to update travisCI to deploy to the `gh-pages` branch on `main` instead